### PR TITLE
export invalidateSize

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,3 +49,4 @@ function install(options) {
 }
 
 module.exports.install = install;
+module.exports.invalidateSize = invalidateSize;


### PR DESCRIPTION
it will be useful if one wants to manually run `invalidateSize`.

For example, with SPA frameworks I can add MutationObserver and trigger `invalidateSize` when DOM is changed.